### PR TITLE
ci: adapt to yocto sstate and hashserve changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,13 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo 'OE_BRANCH='${{ github.ref_name }} >> $GITHUB_ENV
-          if [ ${{ github.ref_name }} = "kirkstone" ]; then
-            echo 'SSTATE_REV=4.0' >> $GITHUB_ENV
-          else
-            echo 'SSTATE_REV=4.0.999' >> $GITHUB_ENV
-          fi
       - name: Configure Environment [pull_request]
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [ ${{ github.base_ref }} = "kirkstone" ]; then
             echo 'OE_BRANCH=kirkstone' >> $GITHUB_ENV
-            echo 'SSTATE_REV=4.0' >> $GITHUB_ENV
           else
             echo 'OE_BRANCH='${{ github.base_ref}} >> $GITHUB_ENV
-            echo 'SSTATE_REV=4.0.999' >> $GITHUB_ENV
           fi
       - name: Install required packages
         run: |
@@ -62,9 +55,9 @@ jobs:
           echo 'INHERIT += "rm_work"' >> conf/local.conf
           echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget zeroconf 3g nfc x11 opengl ptest wayland vulkan gobject-introspection-data"' >> conf/local.conf
           echo 'BB_SIGNATURE_HANDLER = "OEEquivHash"' >> conf/local.conf
-          echo 'SSTATE_MIRRORS += "file://.* http://sstate.yoctoproject.org/dev/${{ env.SSTATE_REV }}/PATH;downloadfilename=PATH"' >> conf/local.conf
+          echo 'SSTATE_MIRRORS += "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"' >> conf/local.conf
           echo 'BB_HASHSERVE = "auto"' >> conf/local.conf
-          echo 'BB_HASHSERVE_UPSTREAM = "typhoon.yocto.io:8687"' >> conf/local.conf
+          echo 'BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"' >> conf/local.conf
           echo 'DISTRO_FEATURES += "openrc"' >> conf/local.conf
           bitbake-layers add-layer ../meta-openrc
       - name: Build operc image


### PR DESCRIPTION
- typhoon was renamed to hashserve
- the sstate cache no longer requires that we specify the yocto release

Signed-off-by: Justin Bronder <jsbronder@cold-front.org>