### PR TITLE
openrc: bump 0.45.2

### DIFF
--- a/recipes-appends/oe-core/rng-tools/rngd.initd
+++ b/recipes-appends/oe-core/rng-tools/rngd.initd
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-	after urandom
+	after seedrng
 	provide entropy
 }
 


### PR DESCRIPTION
Updating rng-tools as well as the urandom script was replaced with seedrng.

Signed-off-by: Justin Bronder <jsbronder@cold-front.org>