### PR TITLE
conf: add OpenRC distro include for $INIT_MANAGER

### DIFF
--- a/conf/distro/include/init-manager-openrc.inc
+++ b/conf/distro/include/init-manager-openrc.inc
@@ -1,0 +1,10 @@
+# Use OpenRC for system initialization
+DISTRO_FEATURES:append = " openrc"
+DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " sysvinit systemd"
+VIRTUAL-RUNTIME_init_manager ??= "openrc-init"
+VIRTUAL-RUNTIME_initscripts ??= "openrc"
+VIRTUAL-RUNTIME_login_manager ??= "busybox"
+VIRTUAL-RUNTIME_dev_manager ??= "busybox-mdev"
+VIRTUAL-RUNTIME_keymaps ??= "openrc"
+# The default, busybox-hwclock, just installs an init script duplicating openrc's
+VIRTUAL-RUNTIME_base-utils-hwclock ?= "openrc"


### PR DESCRIPTION
(This relies on #23 since it sets `openrc-init` as the default init manager).

With this commit, a distro can simply set `INIT_MANAGER := "openrc"` and the corresponding variables will be set automatically.

Long-term, this could also mean we can get rid of the variable setting in `layer.conf`, but seeing as that'd be a breaking change I opted to not include it for this MR.