### PR TITLE
busybox: add command_args_foreground to syslogd scripts

### DIFF
--- a/recipes-appends/oe-core/busybox/busybox-klogd.initd
+++ b/recipes-appends/oe-core/busybox/busybox-klogd.initd
@@ -8,6 +8,7 @@ depend() {
 }
 
 command_args="${COMMAND_ARGS}"
+command_args_foreground="-n"
 description="busybox kernel logger"
 command="/sbin/klogd"
 

--- a/recipes-appends/oe-core/busybox/busybox-syslogd.initd
+++ b/recipes-appends/oe-core/busybox/busybox-syslogd.initd
@@ -8,6 +8,7 @@ depend() {
 }
 
 command_args="${COMMAND_ARGS}"
+command_args_foreground="-n"
 description="busybox system logger"
 command="/sbin/syslogd"
 


### PR DESCRIPTION
This allows them to be correctly ran under a supervisor, such as `supervise-daemon`.