### PR TITLE
openrc: add missing fsck dependency

### DIFF
--- a/recipes-init/openrc/openrc_0.45.2.bb
+++ b/recipes-init/openrc/openrc_0.45.2.bb
@@ -52,6 +52,7 @@ RDEPENDS:${PN} = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'openrc', 'openrc-inittab', '', d)} \
     procps-sysctl \
     sysvinit \
+    util-linux-fsck \
     util-linux-mount \
     util-linux-umount \
 "


### PR DESCRIPTION
OpenRC expects fsck to infer the file system in certain circumstances, something BusyBox fsck will not do.