### PR TITLE
openrc: remove duplicate multicall binaries, symlink instead

### DIFF
--- a/recipes-init/openrc/openrc_0.45.2.bb
+++ b/recipes-init/openrc/openrc_0.45.2.bb
@@ -26,6 +26,16 @@ EXTRA_OEMESON += " \
     -Dpkg_prefix=${prefix} \
 "
 
+symlink_multicalls() {
+    local dir="$1"
+    local dest="$2"
+    shift 2
+    for src in "$@"; do
+        rm "${dir}/${src}"
+        ln -snf "${dest}" "${dir}/${src}"
+    done
+}
+
 do_install:append() {
     # Default sysvinit doesn't do anything with keymaps on a minimal install so
     # we're not going to either.
@@ -45,6 +55,23 @@ do_install:append() {
         fi
         sed -i "s|/sbin/openrc-run|${sbindir}/openrc-run|" ${D}${OPENRC_INITDIR}/volatiles
     fi
+
+    # Many applets are really the same multicall compiled N times, so symlink them to save space.
+    rc_libdir="${D}${@bb.utils.contains('PACKAGECONFIG', 'usrmerge', '${libdir}', '${base_libdir}', d)}/rc"
+    symlink_multicalls "${rc_libdir}/bin" einfo \
+        einfon ewarn ewarnn eerror eerrorn ewend ebegin eend ewend eindent eoutdent \
+        veinfo vewarn vebegin veend vewend veindent veoutdent \
+        esyslog eval_ecolors ewaitfile
+    symlink_multicalls "${rc_libdir}/bin" service_get_value \
+        service_set_value get_options save_options
+    symlink_multicalls "${rc_libdir}/bin" service_started \
+        service_starting service_stopping service_stopped \
+        service_inactive service_wasinactive \
+        service_hotplugged service_started_daemon service_crashed
+    symlink_multicalls "${rc_libdir}/sbin" mark_service_started \
+        mark_service_starting mark_service_stopping mark_service_stopped \
+        mark_service_inactive mark_service_wasinactive \
+        mark_service_hotplugged mark_service_failed mark_service_crashed
 }
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
There is a bunch of binaries in OpenRC that are essentially multicall binaries, but redundantly compiled multiple times:

https://github.com/OpenRC/openrc/blob/0.45.2/src/einfo/meson.build
https://github.com/OpenRC/openrc/blob/0.45.2/src/service/meson.build
https://github.com/OpenRC/openrc/blob/0.45.2/src/mark_service/meson.build
https://github.com/OpenRC/openrc/blob/0.45.2/src/value/meson.build

By symlinking them to one 'main' multicall binary per group, we can reduce rootfs size. As the minimum ARM binary size is pretty big thanks to default 64 kiB alignment in newer binutils, this can be pretty sizable. This saved about 8MB on my test build.