### PR TITLE
github: bitbake in stages to preserve disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,13 @@ jobs:
           else
             echo 'DISTRO_FEATURES += "openrc"' >> conf/local.conf
           fi
-      - name: Build operc image
+      - name: Build openrc image
         run: |
           source poky/oe-init-build-env build
+          # Build in stages so we can wipe tmp in between to stay under the
+          # 14Gb of disk Github gives us.  rm_work isn't sufficient.
+          bitbake openrc
+          rm -rf tmp/
           bitbake openrc-image
       - name: Prune Shared-State Cache and tmpdir
         if: always()


### PR DESCRIPTION
We only have 14Gb [1] of disk and 'rm_work' isn't removing enough to keep us under that limit.  So, bitbake in stages and wipe tmp/ in between in an effort to preserve disk.

1. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources