### PR TITLE
github: bump ubuntu 20.04 -> 24.04 for yocto-check-layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
   yocto-check-layer:
     name: yocto-check-layer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 720
     steps:
       - name: Configure Environment [branch]
@@ -112,7 +112,8 @@ jobs:
           echo 'OE_BRANCH='${{ github.base_ref}} >> $GITHUB_ENV
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get install chrpath diffstat python3-websockets
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This should have been part of 2d401214f45e7e12d2e4647348f0d014d8b1dbc0 but was left off.