### PR TITLE
postinst: fix runlevels link creation if already exist

### DIFF
--- a/classes/openrc.bbclass
+++ b/classes/openrc.bbclass
@@ -29,7 +29,7 @@ openrc_postinst() {
         fi
 
         for script in ${OPENRC_SERVICES}; do
-            ln -s ${OPENRC_INITDIR}/${script} $D${sysconfdir}/runlevels/${OPENRC_RUNLEVEL}/
+            ln -sf ${OPENRC_INITDIR}/${script} $D${sysconfdir}/runlevels/${OPENRC_RUNLEVEL}/
         done
     fi
 


### PR DESCRIPTION
openrc_postinst create a link from init script to runlevels directory during postinstall phase but don't check if already exists nor ignore it.

The posinstall phase could happend at boot or after an opkg package update during configure. If the package init script is already installed and enabled (`OPENRC_AUTO_ENABLE = "enable"`), the link already exists and postinst fails.

This commit just force the link creation and ignore already existing link.