### PR TITLE
pkg config: make newnet meson config optionnal

### DIFF
--- a/recipes-init/openrc/openrc_0.61.bb
+++ b/recipes-init/openrc/openrc_0.61.bb
@@ -14,10 +14,11 @@ DEPENDS += "libcap"
 
 inherit pkgconfig meson
 
-PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'audit pam selinux', d)}"
+PACKAGECONFIG ??= "newnet ${@bb.utils.filter('DISTRO_FEATURES', 'audit pam selinux', d)}"
 
 PACKAGECONFIG[audit] = "-Daudit=enabled,-Daudit=disabled,audit"
 PACKAGECONFIG[bash-completions] = "-Dbash-completions=true,-Dbash-completions=false,bash-completion"
+PACKAGECONFIG[newnet] = "-Dnewnet=true,-Dnewnet=false"
 PACKAGECONFIG[pam] = "-Dpam=true,-Dpam=false,libpam"
 PACKAGECONFIG[selinux] = "-Dselinux=enabled,-Dselinux=disabled,libselinux"
 PACKAGECONFIG[zsh-completions] = "-Dzsh-completions=true,-Dzsh-completions=false"


### PR DESCRIPTION
When openrc is configured with newnet (default), network and staticroute init scripts are bundled and enabled by default which is not desirable if using NetworkManager for example.
This PR makes is configurable (enabled by default to not change current behavior).