### PR TITLE
openrc.bbclass: support service names with dots in variable escaping

### DIFF
--- a/classes/openrc.bbclass
+++ b/classes/openrc.bbclass
@@ -135,7 +135,8 @@ python openrc_populate_packages() {
                 runlevel = localdata.getVar("OPENRC_RUNLEVEL") or "default"
 
             # Create escaped version of service name for shell variables
-            service_escaped = service.replace('-', '_')
+            # replace '-' and '.' with '_' to ensure valid shell variable names
+            service_escaped = service.translate(str.maketrans('-.', '__'))
             if services_escaped:
                 services_escaped += " "
             services_escaped += service_escaped


### PR DESCRIPTION
Replace both dashes and dots with underscores when creating shell variable names from service names (e.g. rpc.svcgssd -> rpc_svcgssd).

@jsbronder You were right! I forgot to handle the '.' and discovered the issue with openrc support for the nfs recipe. Luckily, we can name a variable this way :
`OPENRC_RUNLEVEL:rpc.gssd = "default"`