### PR TITLE
udev-init-scripts: fix Yocto 6.0 UNPACKDIR compatibility

### DIFF
--- a/recipes-init/udev-init-scripts/udev-init-scripts_35.bb
+++ b/recipes-init/udev-init-scripts/udev-init-scripts_35.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://init.d/udev;md5=14c7d7d983a7bc708cc23e88e7cdd856;begi
 SRC_URI = "https://gitweb.gentoo.org/proj/udev-gentoo-scripts.git/snapshot/udev-gentoo-scripts-${PV}.tar.gz"
 SRC_URI[sha256sum] = "51eef30ef99f7f184aa403d190c105c5565e48c1c2d35b1b9f9f052c099fe366"
 
-S = "${WORKDIR}/udev-gentoo-scripts-${PV}"
+S = "${UNPACKDIR}/udev-gentoo-scripts-${PV}"
 
 do_configure[noexec] = "1"
 


### PR DESCRIPTION
## Summary

Yocto 6.0 (Walnascar) changed the default `UNPACKDIR` from `WORKDIR` to `WORKDIR/sources`. This causes a QA error when `S` is set relative to `WORKDIR` instead of `UNPACKDIR`:



## Fix

Change `S = "${WORKDIR}/udev-gentoo-scripts-${PV}"` to `S = "${UNPACKDIR}/udev-gentoo-scripts-${PV}"`.

## Compatibility

`UNPACKDIR` was introduced in Yocto 5.0 (Scarthgap) where it defaults to `WORKDIR`, so this change is backward-compatible with all currently supported Yocto releases. The layer already declares `LAYERSERIES_COMPAT` for `wrynose` which includes Yocto 6.0.

## Testing

Verified that this fix resolves the unpack QA error when building with Yocto 6.0 in our CI (meta-TinyAi project, using this layer).